### PR TITLE
Fix crash with shift+click in empty library

### DIFF
--- a/src/main/java/com/minenash/creative_library/screens/LibraryContentScreen.java
+++ b/src/main/java/com/minenash/creative_library/screens/LibraryContentScreen.java
@@ -303,7 +303,7 @@ public class LibraryContentScreen extends AbstractInventoryScreen<LibraryContent
 
         public void addStack(ItemStack stack) {
             int index = itemList.size() - 1;
-            while (itemList.get(index).isEmpty())
+            while (index > -1 && itemList.get(index).isEmpty())
                 index--;
 
             itemList.set(++index, stack);


### PR DESCRIPTION
```java
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 54
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:359)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at com.minenash.creative_library.screens.LibraryContentScreen$CreativeScreenHandler.addStack(LibraryContentScreen.java:306)
	at com.minenash.creative_library.screens.LibraryContentScreen.onMouseClick(LibraryContentScreen.java:122)
	at net.minecraft.client.gui.screen.ingame.HandledScreen.mouseClicked(HandledScreen.java:362)
	at com.minenash.creative_library.screens.LibraryContentScreen.mouseClicked(LibraryContentScreen.java:174)
	at net.minecraft.client.Mouse.method_1611(Mouse.java:94)
	at net.minecraft.client.gui.screen.Screen.wrapScreenError(Screen.java:491)
	at net.minecraft.client.Mouse.onMouseButton(Mouse.java:94)
	at net.minecraft.client.Mouse.method_22686(Mouse.java:165)
	at net.minecraft.util.thread.ThreadExecutor.execute(ThreadExecutor.java:101)
	at net.minecraft.client.Mouse.method_22684(Mouse.java:165)
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:36)
	at org.lwjgl.system.JNI.invokeV(Native Method)
	at org.lwjgl.glfw.GLFW.glfwPollEvents(GLFW.java:3101)
	at com.mojang.blaze3d.systems.RenderSystem.flipFrame(RenderSystem.java:195)
	at net.minecraft.client.util.Window.swapBuffers(Window.java:310)
	at net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1142)
	at net.minecraft.client.MinecraftClient.run(MinecraftClient.java:733)
	at net.minecraft.client.main.Main.main(Main.java:238)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:608)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:77)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86)
```